### PR TITLE
Fix Travis build error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.1.3)
       sexp_processor (~> 4.1)
-    safe_yaml (0.9.4)
+    safe_yaml (0.9.5)
     sanitize (2.0.4)
       nokogiri (~> 1.6.0)
     sass (3.2.9)


### PR DESCRIPTION
- Update the safe_yaml version to 0.9.5 - the latest present one.
  
  The safe_yaml 0.9.4 version was removed from the rubygems source and
  this causes the `bundle install` to fail.
  
  See https://github.com/dtao/safe_yaml/issues/43
