### PR TITLE
fix eq test of customer_nr in case of id length > 1 digget

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -169,7 +169,7 @@ describe User do
       end
 
       it "should use the user_id" do
-        user.customer_nr.should eq "0000000#{user.id}"
+        user.customer_nr.should eq user.id.to_s.rjust 8, "0"
       end
     end
 


### PR DESCRIPTION
On local testrun the FactoryGirl.create(:user) creates a user with a 2 digget id. This lead to a fail of the test.
