### PR TITLE
Replaced 'x' in news and notices by Font Awesome character

### DIFF
--- a/app/assets/stylesheets/layout/_news_header.scss
+++ b/app/assets/stylesheets/layout/_news_header.scss
@@ -19,8 +19,8 @@
 .l-news-header-close {
   cursor: pointer;
   position: absolute;
-  top: 0.5em;
-  right: 0.5em;
+  top: 1em;
+  right: 1em;
   color: $dark-gray;
   @include clear-links;
   @include user-select(none);

--- a/app/assets/stylesheets/modules/_notice.scss
+++ b/app/assets/stylesheets/modules/_notice.scss
@@ -39,8 +39,8 @@ Styleguide Notice
   cursor: pointer;
   color: white;
   position: absolute;
-  top: 0.5em;
-  right: 0.5em;
+  top: 1em;
+  right: 1em;
   @include clear-links;
   @include user-select(none);
 }

--- a/app/views/application/_notice_layout.html.haml
+++ b/app/views/application/_notice_layout.html.haml
@@ -24,5 +24,4 @@
   .Notice-inner
     = yield
   %a.Notice-close
-    ×
-
+    %i.fa.fa-times-circle.fa-lg

--- a/app/views/layouts/partials/_news_header.html.haml
+++ b/app/views/layouts/partials/_news_header.html.haml
@@ -4,4 +4,4 @@
     .l-news-header-inner
       = news_header
     %a.l-news-header-close
-      ×
+      %i.fa.fa-times-circle.fa-lg


### PR DESCRIPTION
Der Schließen-Button in den News/Notices, der aus einem einfachen 'x' besteht, sieht m.E. nicht so gut aus. Außerdem ist er gerade auf einem Touchscreen-Display sehr schwer zu erwischen.

Hier mein Vorschlag für eine Lösung mit Font-Awesome-Zeichen:

![notice-font-awesome](https://cloud.githubusercontent.com/assets/2727647/3544660/199fa3dc-086f-11e4-98af-63c422edc2ca.png)
