### PR TITLE
Fix "more comments" not showing more comments

### DIFF
--- a/app/views/comments/index.js.erb
+++ b/app/views/comments/index.js.erb
@@ -1,6 +1,13 @@
-$('<%= "##{@commentable.class.to_s.underscore}#{@commentable.id}" %> .Comment-single').last().after('<%= j render @comments %>');
+<%# Check if the id #commentableN exists. We have no commentable id on the single page %>
+commentable_selector = ''
+if ($('<%= "##{@commentable.class.to_s.underscore}#{@commentable.id}" %>').length) {
+  <%# We are on the index page %>
+  commentable_selector = '<%= "##{@commentable.class.to_s.underscore}#{@commentable.id}" %> '
+}
 
-$('<%= "##{@commentable.class.to_s.underscore}#{@commentable.id}" %> .Comments-section .next_link').replaceWith('<%= j(
+$(commentable_selector + '.Comments-section .Comment-single').last().after('<%= j render @comments %>');
+
+$(commentable_selector + '.Comments-section .next_link').replaceWith('<%= j(
     link_to_next_page @comments,
     t("common.text.morecomments"),
     param_name: :comments_page,


### PR DESCRIPTION
When clicking the "more comments" link, no additional comments would
appear.

This was mainly due to a missing `javascript_escape` for `render @comments`
