### PR TITLE
Fix comment creation in single lib view

### DIFF
--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,7 +1,13 @@
-$('<%= "#library#{@commentable.id}" %> .Comments-section form').after($("<%= j render(partial: "comments/comment", locals: {comment: @comment}) %>"));
+commentable_selector = ''
+if ($('<%= "##{@commentable.class.to_s.underscore}#{@commentable.id}" %>').length) {
+  <%# We are on the index page %>
+  commentable_selector = '<%= "##{@commentable.class.to_s.underscore}#{@commentable.id}" %> '
+}
 
-$('<%= "#library#{@commentable.id}" %> #comment_text').val("");
+$(commentable_selector + '.Comments-section form').after($("<%= j render(partial: "comments/comment", locals: {comment: @comment}) %>"));
 
-$('<%= "#library#{@commentable.id}" %> #comments-empty').html("");
+$(commentable_selector + '#comment_text').val("");
+
+$(commentable_selector + '#comments-empty').html("");
 
 


### PR DESCRIPTION
This was again an issue on the single library view, due to different markup. Also replaced the static `#libraryN` with `"##{@commentable.class.to_s.underscore}#{@commentable.id}"`.
