### PR TITLE
Fix too short number inputs on Firefox Mobile/Android

### DIFF
--- a/app/assets/stylesheets/vendor/_formtastic_changes.css.scss
+++ b/app/assets/stylesheets/vendor/_formtastic_changes.css.scss
@@ -51,8 +51,14 @@ textarea {
   @include placeholder {
     color: $gray;
   }
-
 }
+
+
+// Needed for Firefox Mobile
+input[type='number'] {
+  min-width: 3.5em;
+}
+
 
 .formtastic textarea {
   padding: 0.5em;


### PR DESCRIPTION
Firefox Mobile zeigt die number inputs nicht richtig an, es braucht eine CSS min-width. Siehe Issue #949
