### PR TITLE
fixes state changes (forward,backward) to not scroll top #1165

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ config/environments/development.rb
 public/system
 config/initializers/secret_token.rb
 bin
+config/actionmailer.yml
 
 # Project files
 .redcar

--- a/app/assets/javascripts/lazy/wiselinks.js.coffee
+++ b/app/assets/javascripts/lazy/wiselinks.js.coffee
@@ -1,3 +1,13 @@
+
+# extend Wiselinks to add the scroll positions to the history state object
+originalLoad = window._Wiselinks.Page.prototype.load
+window._Wiselinks.Page.prototype.load = (url, target, render = 'template') ->
+    stateData = History.getState().data || {}
+    stateData.scrollX = window.scrollX
+    stateData.scrollY = window.scrollY
+    History.replaceState(stateData, document.title, document.location.href);
+    originalLoad.apply(this, arguments)
+
 $(document).ready ->
     window.wiselinks = new Wiselinks('.l-main', html4: false)
     $(document).off('page:fail').on(
@@ -17,4 +27,18 @@ $(document).ready ->
       'page:done'
       (event, $target, status, url, data) ->
         _paq?.push ['trackPageView']
+    )
+    $(document).on('click', 'a[data-push=true]'
+      (event) ->
+        if ! ($(this).data('scroll') == false)
+          Wiselinks.scrollTop = true
+    )
+    $(document).off('page:always').on('page:always'
+      (event, $target, status, state) ->
+        stateData = History.getState().data
+        if stateData? && stateData.scrollY?
+          window.scroll(stateData.scrollX,stateData.scrollY)
+        else if Wiselinks.scrollTop
+          window.scroll(0,0)
+          Wiselinks.scrollTop = false
     )

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -6,4 +6,6 @@
 /    per_page:      number of items to fetch per page
 /    remote:        data-remote
 li.first*{:class => "#{'active' if current_page.first?}"}
-  = link_to_unless current_page.first?, "1", url, data: (remote ? { remote: true} : { push: true } )
+  - link_attributes ||= {}
+  - link_attributes.deep_merge!(data: (remote ? { remote: true} : { push: true } ))
+  = link_to_unless current_page.first?, "1", url, link_attributes

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -6,4 +6,6 @@
 /    per_page:      number of items to fetch per page
 /    remote:        data-remote
 li.last*{:class => "#{'active' if current_page.last?}"}
-  = link_to_unless current_page.last?, total_pages.to_s, url, data: (remote ? { remote: true} : { push: true } )
+  - link_attributes ||= {}
+  - link_attributes.deep_merge!(data: (remote ? { remote: true} : { push: true } ))
+  = link_to_unless current_page.last?, total_pages.to_s, url, link_attributes

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -6,4 +6,6 @@
 /    per_page:      number of items to fetch per page
 /    remote:        data-remote
 li.next
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', data: (remote ? { remote: true} : { push: true } )
+  - link_attributes ||= {}
+  - link_attributes.deep_merge!(rel: 'next', data: (remote ? { remote: true} : { push: true } ))
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, link_attributes

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -8,4 +8,6 @@
 /    remote:        data-remote
 - unless page.first? || page.last?
   li*{:class => "#{'active' if page.current?}"}
-    = link_to_unless page.current?, page, url, data: (remote ? { remote: true} : { push: true } ), :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil
+    - link_attributes ||= {}
+    - link_attributes.deep_merge!(data: (remote ? { remote: true} : { push: true } ), :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil)
+    = link_to_unless page.current?, page, url, link_attributes

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -6,4 +6,6 @@
 /    per_page:      number of items to fetch per page
 /    remote:        data-remote
 li.prev
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', data: (remote ? { remote: true} : { push: true } )
+  - link_attributes ||= {}
+  - link_attributes.deep_merge!(rel: 'prev', data: (remote ? { remote: true} : { push: true } ))
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, link_attributes

--- a/app/views/layouts/wiselinks.html.slim
+++ b/app/views/layouts/wiselinks.html.slim
@@ -3,8 +3,3 @@ javascript:
 = content_for :view_specific_scripts
 - wiselinks_title ( @page_title || t('common.fairmondo') )
 = yield
-- if content_for? :view_specific_scrolling
-  = yield :view_specific_scrolling
-- else
-  javascript:
-    $("html, body").animate({ scrollTop: 0 }, "fast");

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -21,9 +21,6 @@
 /
 = render 'header'
 - if resource.is? current_user
-  = content_for :view_specific_scrolling do
-    / empty scrolling because the accordion handles this. But we need the script tags or the layout scoll will be active
-    javascript:
   .Accordion.Accordion--activated.Accordion--scrollToActive
     = render '/users/show/article_accordion', item_name: 'active', item_link: new_article_path, articles: active_articles
     = render '/users/show/article_accordion', item_name: 'inactive', articles: inactive_articles

--- a/app/views/users/show/_article_accordion.html.slim
+++ b/app/views/users/show/_article_accordion.html.slim
@@ -9,7 +9,8 @@
     .ArticleListview
       - articles.each do |article|
         = render '/articles/shared/listitem', article: article
-    = paginate articles, params: { active_accordion: item_name } , param_name: "#{item_name}_articles_page"
+
+    = paginate articles, link_attributes: { data: {scroll: false} }, params: { active_accordion: item_name } , param_name: "#{item_name}_articles_page"
 
   - if current_user.type == "LegalEntity"
     p

--- a/app/views/users/show/_line_item_group_accordion.html.slim
+++ b/app/views/users/show/_line_item_group_accordion.html.slim
@@ -9,7 +9,7 @@
     - line_item_groups.each do |group|
       - if group.articles.any?
         = render 'line_item_groups/shared/listitem' , line_item_group: group
-    = paginate line_item_groups, params: { active_accordion: item_name }, param_name: "#{item_name}_page"
+    = paginate line_item_groups, link_attributes: { data: {scroll: false} }, params: { active_accordion: item_name }, param_name: "#{item_name}_page"
 
 / - if current_user.type == 'LegalEntity' && item_name == 'seller_line_item_groups'
 /   .export.JS-active-toggle--container


### PR DESCRIPTION
See #1165.
- The scroll positions are stored as data in the History.js state object.
- data-scroll=false paginate configuration added (kaminar templates updated)
