### PR TITLE
refs #1168, removes obsolete query for image geometry

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -23,23 +23,9 @@ class Image < ActiveRecord::Base
 
   include ::Assets::Normalizer
 
-  # Get The Geometry of a image
-  #
-  # Use the returned Object to get the Size of the image
-  # geo = image.geometry :medium
-  # geo.width
-  # geo.height
-  #
-  # param style [Symbol] style of the image you want the dimensions of
-  # return [Paperclip Geometry Object]
-  def geometry style
-    Paperclip::Geometry.from_file(self.image.path(style))
-  end
-
   def self.reprocess image_id, style = :thumb
     image = Image.find(image_id).image.reprocess! style
   end
-
 
   def write_path_to_file_for(type)
     if Rails.env == 'production'

--- a/app/views/articles/show/_article_contents.html.slim
+++ b/app/views/articles/show/_article_contents.html.slim
@@ -39,7 +39,7 @@
         - if resource.title_image_present?
           / The next line is for providing the proper title image to facebook
           - provide( :title_image, resource.title_image_url(:medium) )
-          = link_to image_tag(resource.title_image_url(:medium), :class=> "title_image",style: "max-width: #{resource.title_image.geometry(:original).width}px"), resource.title_image_url(:original) , {class: "colorbox", rel: "gallery"}
+          = link_to image_tag(resource.title_image_url(:medium), :class=> "title_image"), resource.title_image_url(:original) , {class: "colorbox", rel: "gallery"}
         - else
           = link_to image_tag("missing.png", :class=> "title_image") , "#"
     .thumbnails


### PR DESCRIPTION
This is a quick-fix to avoid server failures for missing images.

We could think about replacing missing image files by the default image, however, usually this files should not get lost and such a feature could "hide" bugs instead of fixing them. 
