### PR TITLE
refs #1186, cleans up wiselinks jQuery hook, atempts to fix start page reload

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -46,6 +46,7 @@
 #= require lazy/wiselinks
 
 #= require customize/wiselinks_ready
+#= require customize/wiselinks_scroll
 
 #= require vendor/jquery.slides.min.js
 #= require vendor/jquery.ba-dotimeout.min.js

--- a/app/assets/javascripts/customize/wiselinks_ready.coffee
+++ b/app/assets/javascripts/customize/wiselinks_ready.coffee
@@ -5,4 +5,4 @@ jQuery.fn.extend
     @each ->
       $(@).ready ->
         callback()
-        $(@).on 'page:done', callback
+        $(@).off('page:always', callback).on('page:always', callback)

--- a/app/assets/javascripts/customize/wiselinks_scroll.coffee
+++ b/app/assets/javascripts/customize/wiselinks_scroll.coffee
@@ -1,0 +1,27 @@
+# extend Wiselinks to add the scroll positions to the history state object
+originalLoad = window._Wiselinks.Page.prototype.load
+window._Wiselinks.Page.prototype.load = (url, target, render = 'template') ->
+  stateData = History.getState().data || {}
+  stateData.scrollX = window.scrollX
+  stateData.scrollY = window.scrollY
+  History.replaceState(stateData, document.title, document.location.href);
+  originalLoad.apply(this, arguments)
+
+$(document).ready ->
+  setScrollTop = ->
+    if ! ($(this).data('scroll') == false)
+      Wiselinks.scrollTop = true
+  $(document)
+    .off('click', 'a[data-push=true]', setScrollTop)
+    .on('click', 'a[data-push=true]', setScrollTop)
+
+  scrollPage = ->
+    stateData = History.getState().data
+    if Wiselinks.scrollTop
+      window.scroll(0,0)
+      Wiselinks.scrollTop = false
+    else if stateData? && stateData.scrollY?
+      window.scroll(stateData.scrollX,stateData.scrollY)
+  $(document)
+    .off('page:always', scrollPage)
+    .on('page:always', scrollPage)

--- a/app/assets/javascripts/lazy/wiselinks.js.coffee
+++ b/app/assets/javascripts/lazy/wiselinks.js.coffee
@@ -1,13 +1,3 @@
-
-# extend Wiselinks to add the scroll positions to the history state object
-originalLoad = window._Wiselinks.Page.prototype.load
-window._Wiselinks.Page.prototype.load = (url, target, render = 'template') ->
-    stateData = History.getState().data || {}
-    stateData.scrollX = window.scrollX
-    stateData.scrollY = window.scrollY
-    History.replaceState(stateData, document.title, document.location.href);
-    originalLoad.apply(this, arguments)
-
 $(document).ready ->
     window.wiselinks = new Wiselinks('.l-main', html4: false)
     $(document).off('page:fail').on(
@@ -27,18 +17,4 @@ $(document).ready ->
       'page:done'
       (event, $target, status, url, data) ->
         _paq?.push ['trackPageView']
-    )
-    $(document).on('click', 'a[data-push=true]'
-      (event) ->
-        if ! ($(this).data('scroll') == false)
-          Wiselinks.scrollTop = true
-    )
-    $(document).off('page:always').on('page:always'
-      (event, $target, status, state) ->
-        stateData = History.getState().data
-        if stateData? && stateData.scrollY?
-          window.scroll(stateData.scrollX,stateData.scrollY)
-        else if Wiselinks.scrollTop
-          window.scroll(0,0)
-          Wiselinks.scrollTop = false
     )

--- a/app/assets/javascripts/visual/slides.coffee
+++ b/app/assets/javascripts/visual/slides.coffee
@@ -1,4 +1,4 @@
-$(document).always ->
+createSliders = ->
   $("#js-billboardslides").slidesjs
     #start: Math.floor(Math.random() * 2) + 1  # random number between 1 and 2
     width: 205
@@ -40,3 +40,5 @@ $(document).always ->
         $("#slide#{m}").css('position', 'absolute')
         $("#slide#{n}").css('position', 'static')
         $("#slide#{o}").css('position', 'absolute')
+
+$(document).always createSliders


### PR DESCRIPTION
As mentioned in the related ticket, there had been some inconsistencies in the way we hook wiselinks into jQuery.
Locally, it's not possible to reproduce the start page reload bug of the staging server. => There might be need of a second PR to fix the related issue.
