### PR TITLE
moves workers that require sidekiq pro to their own queue in production only

### DIFF
--- a/app/workers/queue_disabler_meta_worker.rb
+++ b/app/workers/queue_disabler_meta_worker.rb
@@ -4,7 +4,7 @@ class QueueDisablerMetaWorker
 
   recurrence { daily.hour_of_day(8) }
 
-  sidekiq_options queue: :default,
+  sidekiq_options queue: :sidekiq_pro,
                   retry: 5,
                   backtrace: true
 

--- a/app/workers/queue_enabler_meta_worker.rb
+++ b/app/workers/queue_enabler_meta_worker.rb
@@ -4,7 +4,7 @@ class QueueEnablerMetaWorker
 
   recurrence { daily.hour_of_day(0) }
 
-  sidekiq_options queue: :default,
+  sidekiq_options queue: :sidekiq_pro,
                   retry: 5,
                   backtrace: true
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,6 +5,8 @@ staging:
 production:
   :concurrency: 10
   :timeout: 550
+  :queues:
+    - [sidekiq_pro, 1]
 :queues:
   - [default, 5]
   - [mass_upload, 3]


### PR DESCRIPTION
Else, we constantly spam our sidekiq console with stack traces in development.
