### PR TITLE
refs #1211, avoids separate db call for pagination

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,6 +40,7 @@ class UsersController < ApplicationController
 
   def show
     authorize @user
+    @articles = ActiveUserArticles.new(@user).paginate(params[:active_articles_page])
   end
 
   private

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -40,5 +40,5 @@
 
 - else
   .articles
-    = render '/articles/shared/articles_grid', articles: ActiveUserArticles.new(resource).paginate(params[:active_articles_page])
-  = paginate active_articles, param_name: 'active_articles_page'
+    = render '/articles/shared/articles_grid', articles: @articles
+  = paginate @articles, param_name: 'active_articles_page'


### PR DESCRIPTION
Besides, pagination numbers and content are now in sync even if elasticsearch didn't finish its indexing.
