### PR TITLE
Sellers are allowed to embed iframe elements in their article descriptions

### DIFF
--- a/lib/autoload/sanitization.rb
+++ b/lib/autoload/sanitization.rb
@@ -69,7 +69,7 @@ module Sanitization
         attributes: {
           'a' => ['href', 'type', 'target'],
           'img' => ['src', 'alt'],
-          'iframe' =>  # iframes aren't allowed for non-admins
+          'iframe' =>  # iframes are allowed for non-admins
             ['src', 'frameborder', 'webkitallowfullscreen', 'mozallowfullscreen',
             'allowfullscreen'],
           :all => admin_mode ?

--- a/lib/autoload/sanitization.rb
+++ b/lib/autoload/sanitization.rb
@@ -65,7 +65,7 @@ module Sanitization
         field,
         elements: admin_mode ?
           %w(a b i strong em p h1 h2 h3 h4 h5 h6 br hr ul ol li img div span iframe) :
-          %w(b i strong em p h1 h2 h3 h4 h5 h6 br hr ul ol li),
+          %w(b i strong em p h1 h2 h3 h4 h5 h6 br hr ul ol li iframe),
         attributes: {
           'a' => ['href', 'type', 'target'],
           'img' => ['src', 'alt'],


### PR DESCRIPTION
Non-admins can now embed iframe elements, so that sellers can put videos in their product description.