### PR TITLE
#1249 unified transport now enabled for private users

### DIFF
--- a/app/models/article/validations.rb
+++ b/app/models/article/validations.rb
@@ -76,7 +76,6 @@ module Article::Validations
     validate :only_one_title_image
     validate :bike_courier_requires_paypal, if: :transport_bike_courier
     validate :right_zip_for_courier, if: :transport_bike_courier
-    validate :unified_transport_requires_entry_in_profile, if: :unified_transport
 
   end
 
@@ -146,9 +145,4 @@ module Article::Validations
       end
     end
 
-    def unified_transport_requires_entry_in_profile
-      unless self.seller.unified_transport_provider && self.seller.unified_transport_maximum_articles && self.seller.unified_transport_price
-        errors.add(:unified_transport, I18n.t('article.form.errors.unified_transport_info'))
-      end
-    end
 end

--- a/app/models/article/validations.rb
+++ b/app/models/article/validations.rb
@@ -76,6 +76,7 @@ module Article::Validations
     validate :only_one_title_image
     validate :bike_courier_requires_paypal, if: :transport_bike_courier
     validate :right_zip_for_courier, if: :transport_bike_courier
+    validate :unified_transport_requires_entry_in_profile, if: :unified_transport
 
   end
 
@@ -142,6 +143,12 @@ module Article::Validations
     def right_zip_for_courier
       unless $courier['zip'].include? self.seller.standard_address_zip
         errors.add(:transport_bike_courier, I18n.t('article.form.errors.wrong_zip_for_bike_transport'))
+      end
+    end
+
+    def unified_transport_requires_entry_in_profile
+      unless self.seller.unified_transport_provider && self.seller.unified_transport_maximum_articles && self.seller.unified_transport_price
+        errors.add(:unified_transport, I18n.t('article.form.errors.unified_transport_info'))
       end
     end
 end

--- a/app/views/articles/form/_common_inputs.html.slim
+++ b/app/views/articles/form/_common_inputs.html.slim
@@ -85,7 +85,7 @@
         = f.input :transport_type2_provider, required: true, input_html: {placeholder: t('article.transport.placeholders.type2_provider') }
         = f.input :transport_type2_price, required: true
         = f.input :transport_type2_number, input_html: { min: 1, step: 1 }, tooltip: true
-      = f.input :unified_transport if current_user.is_a? LegalEntity
+      = f.input :unified_transport
       / should generate a warning if not set in the users profile
       = f.input :transport_details, input_html: {rows: 7}
       = f.input :transport_time, tooltip: true, input_html: { class: 'JS-enforce-input-constraints', data: { enforcement_pattern: '/^\d\d?\-?\d?\d?$/' } }

--- a/app/views/devise/registrations/_edit_legal.html.slim
+++ b/app/views/devise/registrations/_edit_legal.html.slim
@@ -35,22 +35,5 @@
       - if resource.cancellation_form.exists?
         | Hochgeladen:
         =< link_to resource.cancellation_form.original_filename, resource.cancellation_form.url, target: '_blank'
-= f.input_step :unified_transport do
-  = f.inputs do
-    .Accordion-step
-      h3.unified_transport_title
-        = t('users.title.unified_transport')
-        span.sprite_helper title=t('users.hints.unified_transport')
-
-      = f.input :unified_transport_provider, :input_html => { :placeholder => t('article.transport.placeholders.type2_provider') }
-      = f.input :unified_transport_price
-      = f.input :unified_transport_maximum_articles, wrapper_html: {class: "unified_transport_maximum_articles"}
-      = t('users.unified_warning')
 
 
-    .Accordion-step.free_transport_step
-      h3.free_transport_title
-        = t('users.title.free_at_transport')
-        span.sprite_helper title=t('users.hints.free_at_transport')
-      = f.input :free_transport_available, wrapper_html: {class: "free_transport_available"}
-      = f.input :free_transport_at_price, wrapper_html: {class: "free_transport_at_price_cents"}

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -146,8 +146,30 @@ h1= t('common.actions.edit_profile')
           = f.input :about_me, as: :text, limit: 2500, input_html: {class: "tinymce"}
           = tinymce
 
+
     - if current_user.is_a?(LegalEntity)
       = render partial: '/devise/registrations/edit_legal', locals: {f: f}
+
+    = f.input_step :unified_transport do
+      = f.inputs do
+        .Accordion-step
+          h3.unified_transport_title
+            = t('users.title.unified_transport')
+            span.sprite_helper title=t('users.hints.unified_transport')
+
+          = f.input :unified_transport_provider, :input_html => { :placeholder => t('article.transport.placeholders.type2_provider') }
+          = f.input :unified_transport_price
+          = f.input :unified_transport_maximum_articles, wrapper_html: {class: "unified_transport_maximum_articles"}
+          = t('users.unified_warning')
+
+
+        - if current_user.is_a?(LegalEntity)
+          .Accordion-step.free_transport_step
+            h3.free_transport_title
+              = t('users.title.free_at_transport')
+              span.sprite_helper title=t('users.hints.free_at_transport')
+            = f.input :free_transport_available, wrapper_html: {class: "free_transport_available"}
+            = f.input :free_transport_at_price, wrapper_html: {class: "free_transport_at_price_cents"}
 
     = f.input_step :payment, tooltip: true do
       = f.inputs do

--- a/config/locales/article/de.yml
+++ b/config/locales/article/de.yml
@@ -147,6 +147,7 @@ de:
         only_one_title_image: "Nur ein Bild kann Titelbild sein!"
         invalid_payment_for_bike_courier: 'Wenn Du Deine Artikel via Fahrradkurier versenden willst, musst Du PayPal als Bezahloption anbieten.'
         wrong_zip_for_bike_transport: 'Du wohnst leider nicht in einem Gebiet, das von unserem Kurierdienstleister versorgt wird.'
+        unified_transport_info: 'Bitte fülle die notwendigen Felder für den Kombiversand in Deinem Nutzer*innen-Profil aus.'
     labels:
       shipping_options: "Versandoptionen:"
       payment_options: "Bezahloptionen:"

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -50,6 +50,10 @@ FactoryGirl.define do
     seller_state "standard_seller"
     buyer_state "standard_buyer"
 
+    unified_transport_provider "DHL"
+    unified_transport_price_cents 2000
+    unified_transport_maximum_articles 12
+
     transient do
       create_standard_address true
     end

--- a/test/features/cart_test.rb
+++ b/test/features/cart_test.rb
@@ -153,8 +153,8 @@ feature 'Checkout' do
   scenario 'User selects cash as unified_payment and does not select pickup and changes it to pickup in the end' do
 
     seller = FactoryGirl.create :legal_entity, :paypal_data
-    articles = [FactoryGirl.create(:article, :with_all_payments, :with_all_transports, seller: seller)]
-    articles << FactoryGirl.create(:article, :with_all_payments, :with_all_transports, seller: seller)
+    articles = [FactoryGirl.create(:article, :with_all_payments, :with_all_transports, seller: seller, unified_transport: false)]
+    articles << FactoryGirl.create(:article, :with_all_payments, :with_all_transports, seller: seller, unified_transport: false)
     login_as FactoryGirl.create(:user)
 
     articles.each do |article|
@@ -240,11 +240,11 @@ feature 'Checkout' do
     unified_seller = FactoryGirl.create :legal_entity, :with_unified_transport_information, :paypal_data
     articles = [FactoryGirl.create(:article, :with_all_payments, :with_all_transports, title: 'unified1', seller: unified_seller),
                 FactoryGirl.create(:article, :with_all_payments, :with_all_transports, title: 'unified2', seller: unified_seller),
-                FactoryGirl.create(:article, :with_all_payments, title: 'single_transport1', seller: unified_seller)]
+                FactoryGirl.create(:article, :with_all_payments, title: 'single_transport1', seller: unified_seller, unified_transport: false)]
 
     single_seller =  FactoryGirl.create :legal_entity, :paypal_data
-    articles << FactoryGirl.create(:article, :with_all_payments, :with_all_transports, title: 'single_transport2', seller: single_seller)
-    articles << FactoryGirl.create(:article, :with_all_payments, :with_all_transports, title: 'single_transport3', seller: single_seller)
+    articles << FactoryGirl.create(:article, :with_all_payments, :with_all_transports, title: 'single_transport2', seller: single_seller, unified_transport: false)
+    articles << FactoryGirl.create(:article, :with_all_payments, :with_all_transports, title: 'single_transport3', seller: single_seller, unified_transport: false)
 
     buyer = FactoryGirl.create(:user)
     login_as buyer


### PR DESCRIPTION
This enables unified transport option for private users

!!! Attention
I added a validation for article.unified_transport to make sure, that the necessary fields in the user profile are set. Hope this doesn't break too many articles in production :)