### PR TITLE
Fixed ie layout error

### DIFF
--- a/app/assets/stylesheets/layout/_main.scss
+++ b/app/assets/stylesheets/layout/_main.scss
@@ -1,5 +1,6 @@
 // main container
 .l-main {
+  display: block;
   @include container($screen-width);
 
   padding: 1rem $screen-padding-mobile 1rem;


### PR DESCRIPTION
Fixed ie layout error (not recognizing main tag as block level element) by applying display:block to main tag element inside div.wrapper